### PR TITLE
minor fix to avoid NaN in CLs_output following issue #3

### DIFF
--- a/madanalysis/misc/simplified_likelihood.py
+++ b/madanalysis/misc/simplified_likelihood.py
@@ -923,7 +923,7 @@ class CLsComputer:
                 CLb = 1. - stats.multivariate_normal.cdf( (qmu - qA)/(2*sqA) )
         # CLs = 0.
         # if CLb > 0.:
-        CLs = CLsb/CLb
+        CLs = CLsb/CLb if CLb > 0. else 1.
         return 1 - CLs
 
 


### PR DESCRIPTION
**Context:**
Minor fix in the simplified likelihoods workflow.

**Description of the Change:**
prevent zero division.

**Benefits:**
In the case of zero division sets CLs to 1. This prevents `NaN` in the `CLs_output.dat`

**Related GitHub Issues:**
see issue #3 