### PR TITLE
Full likelihoods

### DIFF
--- a/madanalysis/misc/run_recast.py
+++ b/madanalysis/misc/run_recast.py
@@ -923,11 +923,10 @@ class RunRecast():
             return -1,-1, -1
         ## Getting the XML information
         try:
-            info_input = open(filename)
-            info_tree = etree.parse(info_input)
-            info_input.close()
+            with open(filename, "r") as info_input:
+                info_tree = etree.parse(info_input)
         except Exception as err:
-            self.logger.warning("Error during HMTL parsing: "+str(err))
+            self.logger.warning("Error during XML parsing: "+str(err))
             self.logger.warning('Cannot parse the info file')
             return -1,-1, -1
 
@@ -1251,9 +1250,15 @@ class RunRecast():
                                     if channel.text != None:
                                         data = channel.text.split()
                                     pyhf_config[likelihood_profile]['SR'][channel.attrib['name']] = {
-                                        'channels' : channel.attrib.get('id',-1),
-                                        'data'     : data
+                                        "channels"    : channel.get('id', default = -1),
+                                        "data"        : data,
                                     }
+                                    is_included = (
+                                            channel.get("is_included", default = 0) in ["True", "1", "yes"]
+                                    ) if len(data) == 0 else True
+                                    pyhf_config[likelihood_profile]['SR'][channel.attrib['name']].update(
+                                        {"is_included" : is_included}
+                                    )
                                     if pyhf_config[likelihood_profile]['SR'][channel.attrib['name']]['channels'] == -1:
                                         file = os.path.join(
                                             pyhf_config[likelihood_profile]['path'],
@@ -1276,7 +1281,7 @@ class RunRecast():
                 continue
             # validat pyhf config
             background = HF_Background(config)
-            signal     = HF_Signal(config,{},xsection=1.,
+            signal     = HF_Signal(config, {}, xsection=1.,
                                    background = background,
                                    validate   = True)
 

--- a/madanalysis/system/detect_simplify.py
+++ b/madanalysis/system/detect_simplify.py
@@ -71,7 +71,7 @@ class DetectSimplify:
 
         # Checking release
         if self.debug:
-            self.logger.debug("  where? = "+simplify.__file__)
+            self.logger.debug("  where? = " + str(simplify.__file__))
 
         # Ok
         return DetectStatusType.FOUND,''


### PR DESCRIPTION
**Description of the Change:**
add the ability to include CRs and VRs in the full likelihoods.

**Benefits:**

- In general, ATLAS analyses are designed such that the signal contamination of CRs is max 10%. So recasting only the SRs but not the CRs/VRs is a good approximation in most cases (as long as the signal hypothesis is not very different from the one the analysis has been designed for). 
- Some analyses do a combined fit to signal and control regions; others don't. If they do, removing the CRs altogether is wrong. If they don't, it makes no difference whether or not the CRs are kept. 

**New options:**
Option introduced in the `.info` file of the analysis e.g.
```
  <pyhf id="RegionC">
    <name>atlas_susy_2018_31_SRC.json</name>
    <regions>
      <channel name="CRtt_cuts"> </channel>
      <channel name="SR_metsigST">
      SRC_22
      SRC_24
      SRC_26
      SRC_28
      </channel>
      <channel name="VRzAlt_cuts" is_included="True"> </channel>
      <channel name="CRz_cuts" is_included="True"> </channel>
      <channel name="VRtt_cuts"> </channel>
      <channel name="VRz_cuts"> </channel>
    </regions>
  </pyhf>
```
If there is no data present in the channel code will look for the `is_included` tag, which can be "True", "yes", "1". If true, the channel will be included in the likelihood calculation; if not, it will be removed. If `is_included` is not present, and the channel does not have any data, it will be removed by default.