### PR TITLE
`PADForSFS` mass execution crash bugfix

### DIFF
--- a/madanalysis/misc/run_recast.py
+++ b/madanalysis/misc/run_recast.py
@@ -307,6 +307,7 @@ class RunRecast():
         from madanalysis.core.script_stack import ScriptStack
         ScriptStack.AddScript(card)
         self.main.recasting.status="off"
+        self.main.superfastsim.Reset()
         script_mode = self.main.script
         self.main.script = True
         from madanalysis.interpreter.interpreter import Interpreter


### PR DESCRIPTION
**Context:**

PADForSFS crashes during a mass execution.

**Description of the Change:**

Reset SFS at the beginning of each PADForSFS run.

**Related GitHub Issues:**

See issue #16 