### PR TITLE
Vectorized SR declaration for cut initialization

### DIFF
--- a/tools/SampleAnalyzer/Process/RegionSelection/RegionSelectionManager.h
+++ b/tools/SampleAnalyzer/Process/RegionSelection/RegionSelectionManager.h
@@ -211,6 +211,49 @@ class RegionSelectionManager
     cutmanager_.AddCut(myname,myregions);
   }
 
+
+  void AddCut(const std::string&name, std::vector<std::string> SRnames)
+  {
+    // The name of the cut
+    std::string myname=name;
+    if(myname.compare("")==0)
+    {
+      std::stringstream numstream;
+      numstream << cutmanager_.GetCuts().size();
+      myname = "Cut" + numstream.str();
+    }
+
+    // Creating the vector of SR of interests
+    std::vector<RegionSelection*> myregions;
+    for(MAuint32 i=0; i<SRnames.size(); i++)
+    {
+      for(MAuint32 j=0; j<regions_.size(); j++)
+      {
+        if(regions_[j]->GetName().compare(SRnames[i])==0)
+        {
+          myregions.push_back(regions_[j]);
+          break;
+        }
+      }
+
+      try
+      {
+        if (myregions.size()==i) throw EXCEPTION_WARNING("Assigning the cut \"" + name +
+                                                         "\" to the non-existing signal region \"" + SRnames[i] +
+                                                         "\"","",0);
+      }
+      catch (const std::exception& e)
+      {
+        MANAGE_EXCEPTION(e);
+      }
+    }
+
+    // Creating the cut
+    cutmanager_.AddCut(myname,myregions);
+
+  }
+
+
   /// Apply a cut
   MAbool ApplyCut(MAbool, std::string const&);
 


### PR DESCRIPTION
**Content**
This PR includes ability to input SRs as vectors alongside with arrays for cut initialization, allowing easier SR handling for analyses with lot of SRs.

**Example**
`user.cpp`:
```cpp
bool user::Initialize(const MA5::Configuration& cfg, const std::map<std::string,std::string>& parameters)
{
  // Initializing PhysicsService for MC
  PHYSICS->mcConfig().Reset();
  AddDefaultHadronic();
  AddDefaultInvisible();

  Manager()->AddRegionSelection("SRA");
  Manager()->AddRegionSelection("SRB");

  std::vector<std::string> SR;
  SR.push_back("SRA");
  SR.push_back("SRB");

  Manager()->AddCut("CUT", SR);

  return true;
}
```

**Related issues**
See issue #26 first requested in [Launchpad](https://answers.launchpad.net/madanalysis5/+question/696991) by Andreas Albert.