### PR TITLE
Declaration for required Python libraries for the usage of entire framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ also be downloaded by by typing `ma5> install zlib` through MadAnalysis interfac
    downloaded from [this link](http://fastjet.fr/). This package can also be installed by 
   typing `ma5> install fastjet` in MadAnalysis.
  - LaTeX and `pdflatex` compilers for report rendering.
-
+ - All Python libraries that MadAnalysis 5 requires can be installed by typing 
+`$ python3 -m pip install -r requirements.txt`.
 
 ### Downloading and installing the MadAnalysis 5 package
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+matplotlib>=3.4.2
+scipy>=1.7.1
+numpy>=1.19.5
+pyhf==0.6.3
+lxml>=4.6.2


### PR DESCRIPTION
`requirements.txt` includes list of packages that MadAnalysis 5 framework uses. By fixing these we can provide more global workspace. How to install the requirements has been mentioned in the readme file.