### PR TITLE
Depracate python based third party software installation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -28,6 +28,10 @@
  * We added an interface to include CRs and VRs with using full likelihoods.
    ([#5](https://github.com/MadAnalysis/madanalysis5/pull/5))
 
+ * Installation of Python-based third-party software has been deprecated. 
+   This now will be handled through `requirements.txt`.
+   ([#68](https://github.com/MadAnalysis/madanalysis5/pull/68))
+
 ## Bug fixes
  * Zero division error fixed in the simplified likelihoods workflow.
    ([#4](https://github.com/MadAnalysis/madanalysis5/pull/4))

--- a/madanalysis/interpreter/cmd_install.py
+++ b/madanalysis/interpreter/cmd_install.py
@@ -26,7 +26,7 @@ from __future__                             import absolute_import
 from madanalysis.interpreter.cmd_base       import CmdBase
 from madanalysis.install.install_manager    import InstallManager
 from six.moves import input
-import logging, os
+import logging, os, sys
 
 
 class CmdInstall(CmdBase):
@@ -73,7 +73,7 @@ class CmdInstall(CmdBase):
                 elif os.path.isfile(os.path.join(dpath,libname+'.dylib')):
                     mylib = os.path.join(dpath,libname+'.dylib')
                 else:
-                    return;
+                    return True
 
                 main.archi_info.libraries[to_activate]= mylib+":"+str(os.stat(mylib).st_mtime)
 
@@ -127,11 +127,15 @@ class CmdInstall(CmdBase):
         elif args[0]=='gnuplot':
             return installer.Execute('gnuplot')
         elif args[0]=='matplotlib':
-            return installer.Execute('matplotlib')
+            self.logger.warning("This command has been deprecated.")
+            self.logger.warning(f"Please use '{sys.executable} -m pip install -r requirements.txt' instead.")
+            return True
         elif args[0]=='root':
             return installer.Execute('root')
         elif args[0]=='numpy':
-            return installer.Execute('numpy')
+            self.logger.warning("This command has been deprecated.")
+            self.logger.warning(f"Please use '{sys.executable} -m pip install -r requirements.txt' instead.")
+            return True
         elif args[0]=='PADForMA5tune':
             if inst_delphes(self.main,installer,'delphesMA5tune',True):
                 return installer.Execute('PADForMA5tune')
@@ -188,12 +192,9 @@ class CmdInstall(CmdBase):
                     return 'restart'
             return padsfs_install_check
         elif args[0]=='pyhf':
-            if self.main.session_info.has_scipy:
-                return installer.Execute('pyhf')
-            else:
-                self.logger.error("The PYHF module requires scipy, please retry"+\
-                                  "after installing scipy.")
-                return True
+            self.logger.warning("This command has been deprecated.")
+            self.logger.warning(f"Please use '{sys.executable} -m pip install -r requirements.txt' instead.")
+            return True
         elif args[0]=='likelihood_simplifier':
             if self.main.session_info.has_scipy and self.main.session_info.has_pyhf:
                 return installer.Execute('simplify')


### PR DESCRIPTION
**Context:**
This PR deprecates the installation of third-party software based on python. These can now be installed directly through `requirements.txt`.

**Benefits:**
Increases stability of the software.

**Related GitHub Issues:**
See issue #67 