### PR TITLE
Bugfix for covariance matrix construction for simplified likelihoods

### DIFF
--- a/bin/ma5
+++ b/bin/ma5
@@ -6,7 +6,7 @@
 #  The MadAnalysis development team, email: <ma5team@iphc.cnrs.fr>
 #  
 #  This file is part of MadAnalysis 5.
-#  Official website: <https://launchpad.net/madanalysis5>
+#  Official website: <https://github.com/MadAnalysis/madanalysis5>
 #  
 #  MadAnalysis 5 is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -69,8 +69,8 @@ sys.path.insert(0, servicedir)
 
 # Release version
 # Do not touch it !!!!!  
-version = "1.10.1"
-date = "2022/01/15"
+version = "1.10.2"
+date = "2022/06/08"
 
 # Loading the MadAnalysis session
 import madanalysis.core.launcher

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -61,4 +61,4 @@
 
 This release contains contributions from (in alphabetical order):
 
-[Jack Y. Araz](@jackaraz), [Benjamin Fuks](@BFuks)
+[Jack Y. Araz](https://github.com/jackaraz), [Benjamin Fuks](https://github.com/bfuks)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -54,9 +54,11 @@
    ([#56](https://github.com/MadAnalysis/madanalysis5/pull/56))
  * Negative value can now be used for SFS bounds.
    ([#52](https://github.com/MadAnalysis/madanalysis5/pull/52))
+ * Bugfix for covariance matrix construction when global likelihood switch is off.
+   ([#88](https://github.com/MadAnalysis/madanalysis5/pull/88))
 
 ## Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Jack Y. Araz, Benjamin Fuks
+[Jack Y. Araz](@jackaraz), [Benjamin Fuks](@BFuks)

--- a/madanalysis/misc/run_recast.py
+++ b/madanalysis/misc/run_recast.py
@@ -1033,26 +1033,26 @@ class RunRecast():
                 except Exception as err:
                     self.logger.warning('Invalid info file (' + analysis+ '): ill-defined lumi')
                     self.logger.debug(str(err))
-                    return -1,-1,-1
+                    return -1, -1, -1
                 self.logger.debug('The luminosity of ' + analysis + ' is ' + str(lumi) + ' fb-1.')
             # regions
             if child.tag == "region" and ("type" not in child.attrib or child.attrib["type"] == "signal"):
                 if "id" not in child.attrib:
                     self.logger.warning('Invalid info file (' + analysis+ '): <region id> tag.')
-                    return -1,-1,-1
+                    return -1, -1, -1
                 if child.attrib["id"] in regions:
                     self.logger.warning('Invalid info file (' + analysis+ '): doubly-defined region.')
-                    return -1,-1,-1
+                    return -1, -1, -1
                 regions.append(child.attrib["id"])
                 # If one covariance entry is found, the covariance switch is turned on
-                if "covariance" in [rchild.tag for rchild in child]:
-                    for grand_child in [gchild for gchild in child if gchild.tag == "covariance"]:
+                if self.main.recasting.global_likelihoods_switch:
+                    for grand_child in child.findall("covariance"):
                         if "cov_subset" in info_root.attrib:
                             if grand_child.attrib.get("cov_subset", "default") in [info_root.attrib["cov_subset"], "default"]:
                                 if child.attrib["id"] not in self.cov_config[info_root.attrib["cov_subset"]]["cov_regions"]:
                                     self.cov_config[info_root.attrib["cov_subset"]]["cov_regions"].append(child.attrib["id"])
                         else:
-                            if grand_child.attrib.get("cov_subset", False) != False:
+                            if grand_child.attrib.get("cov_subset", False):
                                 subsetID = grand_child.attrib["cov_subset"]
                                 if subsetID not in list(self.cov_config.keys()):
                                     self.cov_config[subsetID] = dict(cov_regions = [],
@@ -1118,7 +1118,7 @@ class RunRecast():
                         err_scale = lumi_scaling
                         deltanb = round(deltanb*err_scale,8)
                     else:
-                        nb_new = nb*lumi_scaling;
+                        nb_new = nb*lumi_scaling
                         deltanb = round(math.sqrt(self.main.recasting.error_extrapolation[0]**2*nb_new**2 
                                                   + self.main.recasting.error_extrapolation[1]**2*nb_new), 8);
                 else:

--- a/tools/SampleAnalyzer/Commons/Base/Configuration.cpp
+++ b/tools/SampleAnalyzer/Commons/Base/Configuration.cpp
@@ -40,8 +40,8 @@ using namespace MA5;
 // Initializing static data members
 // -----------------------------------------------------------------------------
 // DO NOT TOUCH THESE LINES
-const std::string Configuration::sampleanalyzer_version_ = "1.10.1";
-const std::string Configuration::sampleanalyzer_date_    = "2022/01/15";
+const std::string Configuration::sampleanalyzer_version_ = "1.10.2";
+const std::string Configuration::sampleanalyzer_date_    = "2022/06/08";
 // DO NOT TOUCH THESE LINES
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**Context**
This update fixes a bug in PAD for cases where the global likelihoods are turned off but the covariance matrix is available in the info file.

**Issues**
See issue #87 