### PR TITLE
Update ma5

### DIFF
--- a/bin/ma5
+++ b/bin/ma5
@@ -33,11 +33,10 @@ and call immediately the command line interface scripts"""
 
 # Checking if the correct release of Python is installed
 import sys
-if  (sys.version_info[0] == 2 and sys.version_info[1] < 7) or (sys.version_info[0] == 3 and sys.version_info[1] < 8):
+if  sys.version_info[0] != 3 or sys.version_info[1] <= 7:
     sys.exit('Python release '+ sys.version + ' is detected.\n' + \
-    'MadAnalysis 5 works only with python 2.7 ' + \
-    'or  python 3.8 and later.\n' + \
-    'Please upgrade your version of python.')
+    'MadAnalysis 5 works only with Python version 3.8 and more recent version.\n' + \
+    'Please upgrade your Python installation.')
 
 # Checking that the 'six' package is present
 try:

--- a/bin/ma5
+++ b/bin/ma5
@@ -33,7 +33,7 @@ and call immediately the command line interface scripts"""
 
 # Checking if the correct release of Python is installed
 import sys
-if  sys.version_info[0] != 3 or sys.version_info[1] <= 7:
+if  sys.version_info[0] != 3 or sys.version_info[1] <= 6:
     sys.exit('Python release '+ sys.version + ' is detected.\n' + \
     'MadAnalysis 5 works only with Python version 3.8 and more recent version.\n' + \
     'Please upgrade your Python installation.')

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -44,6 +44,9 @@
 
  * Debug mode message has been extended to include module, function and file names 
    with line number. ([#90](https://github.com/MadAnalysis/madanalysis5/pull/90))
+ 
+ * Set hard limit to python version to 3.7+
+   ([#92](https://github.com/MadAnalysis/madanalysis5/pull/92))
 
 ## Bug fixes
  * Zero division error fixed in the simplified likelihoods workflow.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -45,7 +45,7 @@
  * Debug mode message has been extended to include module, function and file names 
    with line number. ([#90](https://github.com/MadAnalysis/madanalysis5/pull/90))
  
- * Set hard limit to python version to 3.7+
+ * Set hard limit to python version to 3.6+ (PS: lxplus uses 3.6 minimum)
    ([#92](https://github.com/MadAnalysis/madanalysis5/pull/92))
 
 ## Bug fixes


### PR DESCRIPTION
**Context:**
Updating requirements.

**Description of the Change:**
Versions of Python older than 3.7 cannot be used with the code anymore

**Benefits:**
Allowing to use newer Python developments.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.