### PR TITLE
Bugfix in RecEventFormat Memory allocation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -84,6 +84,9 @@
    from the generated analyses.
    ([#96](https://github.com/MadAnalysis/madanalysis5/pull/96)).
 
+ * `RecEventFormat` memory allocation for MC particles has been freed
+   ([#100](https://github.com/MadAnalysis/madanalysis5/pull/100)).
+
 ## Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/tools/SampleAnalyzer/Commons/DataFormat/RecEventFormat.h
+++ b/tools/SampleAnalyzer/Commons/DataFormat/RecEventFormat.h
@@ -160,7 +160,18 @@ class RecEventFormat
 
   /// Destructor
   ~RecEventFormat()
-  { }
+  {
+     for (auto &p: MCHadronicTaus_)
+         if (p != 0) delete p;
+      for (auto &p: MCMuonicTaus_)
+          if (p != 0) delete p;
+      for (auto &p: MCElectronicTaus_)
+          if (p != 0) delete p;
+      for (auto &p: MCBquarks_)
+          if (p != 0) delete p;
+      for (auto &p: MCCquarks_)
+          if (p != 0) delete p;
+  }
 
   /// Accessor to the photon collection (read-only)
   const std::vector<RecPhotonFormat>& photons() const {return photons_;}


### PR DESCRIPTION
**Context**
This update frees the heap allocation for MC particle collections.