### PR TITLE
fixed regionSelectionManager destructor

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,8 +4,15 @@
 
 ## Improvements
 
+RegionSelectionManager Object should not longer leak memory
+
 ## Bug fixes
+
+Fixed destructor in RegionSelectionManager so that RegionSelection objects allocated inside the region_ vector are properly destructed upon existing scope/destruction of RegionSelectionManager.
+
 
 ## Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Jack Araz, Kyle Fan, Benjamin Fuks

--- a/tools/SampleAnalyzer/Process/RegionSelection/RegionSelectionManager.h
+++ b/tools/SampleAnalyzer/Process/RegionSelection/RegionSelectionManager.h
@@ -73,7 +73,6 @@ class RegionSelectionManager
   RegionSelectionManager() {};
 
   /// Destructor
-  // 
   ~RegionSelectionManager() { 
     for(auto &region_pointer : regions_){
       delete region_pointer;

--- a/tools/SampleAnalyzer/Process/RegionSelection/RegionSelectionManager.h
+++ b/tools/SampleAnalyzer/Process/RegionSelection/RegionSelectionManager.h
@@ -73,7 +73,12 @@ class RegionSelectionManager
   RegionSelectionManager() {};
 
   /// Destructor
-  ~RegionSelectionManager() { };
+  // 
+  ~RegionSelectionManager() { 
+    for(auto &region_pointer : regions_){
+      delete region_pointer;
+    }
+  };
 
   /// Reset
   void Reset()


### PR DESCRIPTION
destructor now deletes allocated region selection objects when going out of scope.

