### PR TITLE
Merging `fatjets` and `genjets` into `jetcollection`

### DIFF
--- a/tools/SampleAnalyzer/Commons/DataFormat/RecEventFormat.cpp
+++ b/tools/SampleAnalyzer/Commons/DataFormat/RecEventFormat.cpp
@@ -39,7 +39,6 @@ namespace MA5 {
         muons_.clear();
         taus_.clear();
         jetcollection_.clear();
-        fatjets_.clear();
         emptyjet_.clear();
 #ifdef MA5_FASTJET_MODE
         // pseudojet : only available when fastjet is in use (code efficiency)
@@ -57,7 +56,6 @@ namespace MA5 {
         EFlowPhotons_.clear();
         EFlowNeutralHadrons_ok_=false;
         EFlowNeutralHadrons_.clear();
-        genjets_.clear();
         MET_.Reset();
         MHT_.Reset();
         TET_  = 0.;
@@ -223,15 +221,21 @@ namespace MA5 {
     /// Giving a new fat jet entry
     RecJetFormat* RecEventFormat::GetNewFatJet()
     {
-        fatjets_.push_back(RecJetFormat());
-        return &fatjets_.back();
+        std::string id = "fatjet";
+        std::pair< std::map<std::string, std::vector<RecJetFormat> >::iterator,bool> new_jet;
+        new_jet = jetcollection_.insert(std::make_pair(id,std::vector<RecJetFormat>() ));
+        new_jet.first->second.push_back(RecJetFormat());
+        return &(new_jet.first->second.back());
     }
 
     /// Giving a new gen jet entry
     RecJetFormat* RecEventFormat::GetNewGenJet()
     {
-        genjets_.push_back(RecJetFormat());
-        return &genjets_.back();
+        std::string id = "genjet";
+        std::pair< std::map<std::string, std::vector<RecJetFormat> >::iterator,bool> new_jet;
+        new_jet = jetcollection_.insert(std::make_pair(id,std::vector<RecJetFormat>() ));
+        new_jet.first->second.push_back(RecJetFormat());
+        return &(new_jet.first->second.back());
     }
 
     /// Giving a new track entry

--- a/tools/SampleAnalyzer/Commons/DataFormat/RecEventFormat.h
+++ b/tools/SampleAnalyzer/Commons/DataFormat/RecEventFormat.h
@@ -103,12 +103,10 @@ namespace MA5
         // Identification of the primary jet. Corresponds to content of the jets_
         std::string PrimaryJetID_;
 
-        /// Collection of reconstructed fat jets
-        std::vector<RecJetFormat>    fatjets_;
-
         /// Collection of reconstructed jet dictionary
         // @JACK note for the future: if lots of jet input is used change map
         // to unordered map for efficiency UI is the same!
+        // 29.09.2022 - Jack: fatjet and genjet is added to jetcollection
         std::map<std::string, std::vector<RecJetFormat> > jetcollection_;
 
 #ifdef MA5_FASTJET_MODE
@@ -118,9 +116,6 @@ namespace MA5
 
         /// Create an empty jet
         std::vector<RecJetFormat>    emptyjet_;
-
-        /// Collection of generated jets
-        std::vector<RecJetFormat>    genjets_;
 
         /// Collection of reconstructed tracks
         MAbool tracks_ok_;
@@ -214,7 +209,16 @@ namespace MA5
         const std::vector<RecTauFormat>& taus() const {return taus_;}
 
         /// Accessor to the fat jet collection (read-only)
-        const std::vector<RecJetFormat>& fatjets() const {return fatjets_;}
+        const std::vector<RecJetFormat>& fatjets() const
+        {
+            std::string id = "fatjet";
+            if (jetcollection_.find(id) != jetcollection_.end())
+                return jetcollection_.at(id);
+            else
+            {
+                return emptyjet_;
+            }
+        }
 
         /// Accessor to the jet collection (read-only)
         const std::vector<RecJetFormat>& jets() const
@@ -242,7 +246,16 @@ namespace MA5
         }
 
         /// Accessor to the genjet collection (read-only)
-        const std::vector<RecJetFormat>& genjets() const {return genjets_;}
+        const std::vector<RecJetFormat>& genjets() const
+        {
+            std::string id = "genjet";
+            if (jetcollection_.find(id) != jetcollection_.end())
+                return jetcollection_.at(id);
+            else
+            {
+                return emptyjet_;
+            }
+        }
 
         /// Accessor to the track collection (read-only)
         const std::vector<RecTrackFormat>& tracks() const {return tracks_;}
@@ -329,7 +342,16 @@ namespace MA5
         }
 
         /// Accessor to the fat jet collection
-        std::vector<RecJetFormat>& fatjets() {return fatjets_;}
+        std::vector<RecJetFormat>& fatjets()
+        {
+            std::string id = "fatjet";
+            if (jetcollection_.find(id) != jetcollection_.end())
+                return jetcollection_.at(id);
+            else
+            {
+                return emptyjet_;
+            }
+        }
 
         /// Accessor to the towers collection
         std::vector<RecTowerFormat>& towers() {return towers_;}
@@ -338,7 +360,16 @@ namespace MA5
         std::vector<RecParticleFormat>& EFlowNeutralHadrons() {return EFlowNeutralHadrons_;}
 
         /// Accessor to the jet collection
-        std::vector<RecJetFormat>& genjets() {return genjets_;}
+        std::vector<RecJetFormat>& genjets()
+        {
+            std::string id = "genjet";
+            if (jetcollection_.find(id) != jetcollection_.end())
+                return jetcollection_.at(id);
+            else
+            {
+                return emptyjet_;
+            }
+        }
 
         /// Accessor to the track collection
         std::vector<RecTrackFormat>& tracks() {return tracks_;}

--- a/tools/SampleAnalyzer/Interfaces/delphes/DelphesTreeReader.cpp
+++ b/tools/SampleAnalyzer/Interfaces/delphes/DelphesTreeReader.cpp
@@ -612,7 +612,7 @@ void DelphesTreeReader::FillEvent(EventFormat& myEvent, SampleFormat& mySample)
   if (data_.FatJet_!=0)
   {
     MAuint32 njets = static_cast<MAuint32>(data_.FatJet_->GetEntries());
-    myEvent.rec()->fatjets_.reserve(njets);
+    // myEvent.rec()->fatjets_.reserve(njets);
     for (MAuint32 i=0;i<njets;i++)
     {
       // getting the i-th particle


### PR DESCRIPTION
**Context:**
This PR integrates `fatjets` and `genjets` into `jetcollection` to unify all jet collections under one map.