### PR TITLE
Compiler options for the LHCO reader

### DIFF
--- a/bin/ma5
+++ b/bin/ma5
@@ -67,8 +67,8 @@ sys.path.insert(0, servicedir)
 
 # Release version
 # Do not touch it !!!!!  
-version = "2.0.5"
-date = "2022/09/29"
+version = "2.0.6"
+date = "2023/01/12"
 
 # Loading the MadAnalysis session
 import madanalysis.core.launcher

--- a/doc/releases/changelog-v2.0.md
+++ b/doc/releases/changelog-v2.0.md
@@ -59,10 +59,6 @@
 * Jet collection accessor has been fixed in DelphesMa5Tune
   ([#135](https://github.com/MadAnalysis/madanalysis5/pull/135))
 
-* Submit function has been modified to eliminate issues with LHCO 
-  reader mentioned in issue [#136](https://github.com/MadAnalysis/madanalysis5/issues/136).
-  ([#167](https://github.com/MadAnalysis/madanalysis5/pull/167))
-
 ## Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-v2.0.md
+++ b/doc/releases/changelog-v2.0.md
@@ -59,6 +59,10 @@
 * Jet collection accessor has been fixed in DelphesMa5Tune
   ([#135](https://github.com/MadAnalysis/madanalysis5/pull/135))
 
+* Submit function has been modified to eliminate issues with LHCO 
+  reader mentioned in issue [#136](https://github.com/MadAnalysis/madanalysis5/issues/136).
+  ([#167](https://github.com/MadAnalysis/madanalysis5/pull/167))
+
 ## Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-v2.0.md
+++ b/doc/releases/changelog-v2.0.md
@@ -59,6 +59,10 @@
 * Jet collection accessor has been fixed in DelphesMa5Tune
   ([#135](https://github.com/MadAnalysis/madanalysis5/pull/135))
 
+* Submit function has been modified to eliminate issues with LHCO
+  reader mentioned in issue [#136](https://github.com/MadAnalysis/madanalysis5/issues/136).
+  ([#167](https://github.com/MadAnalysis/madanalysis5/pull/167))
+
 ## Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/madanalysis/interpreter/cmd_submit.py
+++ b/madanalysis/interpreter/cmd_submit.py
@@ -418,19 +418,23 @@ class CmdSubmit(CmdBase):
         # SFS-FastJet mode, the analysis has to be compiled with the
         # `-DMA5_FASTJET_MODE` flag. This however needs to be deactivated for
         # Delphes-ROOT based analyses.
-        root_dataset, hepmc_dataset = False, False
+        root_dataset, hepmc_dataset, lhco_dataset = False, False, False
         for dataset in self.main.datasets:
             for sample in dataset:
                 if "hepmc" in sample:
                     hepmc_dataset = True
                 elif "root" in sample:
                     root_dataset = True
+                elif "lhco" in sample:
+                    lhco_dataset = True
         if self.main.fastsim.package in ["delphes","delphesMA5tune"] or root_dataset:
             os.environ["FASTJET_FLAG"] = ""
         elif self.main.fastsim.package in ["fastjet"] and hepmc_dataset:
             if root_dataset and hepmc_dataset:
                 self.logger.error("ROOT input files not allowed for SFS-FastJet based analyses.")
                 return False
+            os.environ["FASTJET_FLAG"] = "-DMA5_FASTJET_MODE"
+        elif self.main.fastsim.package == 'none' and self.main.archi_info.has_fastjet and lhco_dataset:
             os.environ["FASTJET_FLAG"] = "-DMA5_FASTJET_MODE"
 
         if self.resubmit and not self.main.recasting.status=='on':

--- a/tools/SampleAnalyzer/Commons/Base/Configuration.cpp
+++ b/tools/SampleAnalyzer/Commons/Base/Configuration.cpp
@@ -40,8 +40,8 @@ using namespace MA5;
 // Initializing static data members
 // -----------------------------------------------------------------------------
 // DO NOT TOUCH THESE LINES
-const std::string Configuration::sampleanalyzer_version_ = "2.0.5";
-const std::string Configuration::sampleanalyzer_date_    = "2022/09/29";
+const std::string Configuration::sampleanalyzer_version_ = "2.0.6";
+const std::string Configuration::sampleanalyzer_date_    = "2023/01/12";
 // DO NOT TOUCH THESE LINES
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR modifies the submit function to avoid memory leaks while reading LHCO files.

**Note: Be aware that there might be other memory leaks; this update does not solve the issue. It just eliminates one specific case!!**