### PR TITLE
chore: Update pyhf to v0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ The [latest release](https://github.com/MadAnalysis/madanalysis5/releases) of Ma
 - [FastJet](http://fastjet.fr) v3.3.3
 - [Delphes](https://github.com/delphes/delphes) v3.5.0
 - [ROOT](https://root.cern) v6.04.08
-- [pyhf](https://github.com/scikit-hep/pyhf) v0.7.0
+- [pyhf](https://github.com/scikit-hep/pyhf) v0.7.3
 
 ### Authors
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,8 +4,14 @@
 
 ## Improvements
 
+* The required version of pyhf was updated to v0.7.3 to take advantage of recent
+  edge case bug fixes.
+([#211](https://github.com/MadAnalysis/madanalysis5/pull/211))
+
 ## Bug fixes
 
 ## Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Matthew Feickert](https://github.com/matthewfeickert)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib>=3.4.2
 scipy>=1.7.1
 numpy>=1.19.5
-pyhf==0.7.0
+pyhf==0.7.3
 lxml>=4.6.2


### PR DESCRIPTION
**Context:**

* Update pyhf to the latest patch release of the v0.7.x series.
* Note updates in dev changelog.

**Description of the Change:**

Update to `pyhf` `v0.7.3`, the latest patch release in the `pyhf` `v0.7.x` series.

**Benefits:**

Guard against edge case bugs that were found and patched since `pyhf` `v0.7.0`.

**Possible Drawbacks:**

None. The API and the lower bounds on requirements are unchanged.

**Related GitHub Issues:**

None.