### PR TITLE
small bug with uncertainty calculation on the recast module

### DIFF
--- a/doc/releases/changelog-v1.10.md
+++ b/doc/releases/changelog-v1.10.md
@@ -135,7 +135,7 @@
 
 * Covariance matrix implementation has been fixed for HL extrapolations 
   (see issue [#223](https://github.com/MadAnalysis/madanalysis5/issues/223)).
-  ([#225](https://github.com/MadAnalysis/madanalysis5/pull/225))
+  ([#225](https://github.com/MadAnalysis/madanalysis5/pull/225)) and ([#245](https://github.com/MadAnalysis/madanalysis5/pull/245))
 
 ## Contributors
 

--- a/madanalysis/misc/run_recast.py
+++ b/madanalysis/misc/run_recast.py
@@ -1145,7 +1145,7 @@ class RunRecast():
                 if self.main.recasting.error_extrapolation=='sqrt':
                     new_sigma = round(math.sqrt(sigma)*lumi_scaling,8)
                 elif self.main.recasting.error_extrapolation=='linear':
-                    new_sigma *= lumi_scaling**2
+                    new_sigma = sigma*lumi_scaling**2
                 else:
                     new_sigma = sigma * lumi_scaling**2 * self.main.recasting.error_extrapolation[0]**2 + \
                         np.sqrt(sigma) * lumi_scaling * self.main.recasting.error_extrapolation[1]**2


### PR DESCRIPTION
**Context:** Small crash in the covariance calculation (in one of the case for the luminosity scaling, one variable was modified prior to being initialised.

**Description of the Change:** Fixed the bug by proper assignment of the variable.

**Benefits:** n.a.

**Possible Drawbacks:** n.a.

**Related GitHub Issues:** none
