### PR TITLE
feat: Add getters to Histo

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,7 +2,7 @@
 
 ## New features since last release
 
-- Expert mode: `Histo` protected properties now have getters, e.g. `Manager()->GetPlotManager()->GetHistos()[0]->Nbins()`. See https://github.com/MadAnalysis/madanalysis5/pull/247.
+- In expert mode, all `Histo` protected properties like `nbins_` now have getters, e.g. `Manager()->GetPlotManager()->GetHistos()[0]->Nbins()` ([#247](https://github.com/MadAnalysis/madanalysis5/pull/247)).
 
 ## Improvements
 
@@ -12,4 +12,4 @@
 
 This release contains contributions from (in alphabetical order):
 
-- Bastien Voirin
+[Bastien Voirin](https://github.com/bastienvoirin)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,6 +2,8 @@
 
 ## New features since last release
 
+- Expert mode: `Histo` protected properties now have getters, e.g. `Manager()->GetPlotManager()->GetHistos()[0]->Nbins()`. See https://github.com/MadAnalysis/madanalysis5/pull/247.
+
 ## Improvements
 
 ## Bug fixes
@@ -9,3 +11,5 @@
 ## Contributors
 
 This release contains contributions from (in alphabetical order):
+
+- Bastien Voirin

--- a/tools/SampleAnalyzer/Process/Plot/Histo.h
+++ b/tools/SampleAnalyzer/Process/Plot/Histo.h
@@ -204,6 +204,32 @@ class Histo : public PlotBase
     }
   }
 
+  /// Histogram arrays
+  std::vector< std::pair<MAfloat64,MAfloat64> > Histo() { return histo_; }
+  std::pair<MAfloat64, MAfloat64> Underflow() { return underflow_; }
+  std::pair<MAfloat64, MAfloat64> Overflow() { return overflow_; }
+
+  /// Histogram description
+  MAuint32  Nbins() { return nbins_; }
+  MAfloat64 Xmin() { return xmin_; }
+  MAfloat64 Xmax() { return xmax_; }
+  MAfloat64 Step() { return step_; }
+
+  /// Sum of event-weights over entries
+  std::pair<MAfloat64,MAfloat64> SumW() { return sum_w_; }
+
+  /// Sum of squared weights
+  std::pair<MAfloat64,MAfloat64> SumWW() { return sum_ww_; }
+
+  /// Sum of value * weight
+  std::pair<MAfloat64,MAfloat64> SumXW() { return sum_xw_; }
+
+  /// Sum of value * value * weight
+  std::pair<MAfloat64,MAfloat64> SumXXW() { return sum_xxw_; }
+
+  /// RegionSelections attached to the histo
+  std::vector<RegionSelection*> Regions() { return regions_; }
+
   /// Write the plot in a ROOT file
   virtual void Write_TextFormat(std::ostream* output);
 


### PR DESCRIPTION
**Context:**

https://github.com/MadAnalysis/madanalysis5/blob/d08d3840ef7f47666bb02de48df20ade8a7e4d54/tools/SampleAnalyzer/Process/Plot/Histo.cpp#L129-L161 was removed by https://github.com/MadAnalysis/madanalysis5/commit/7db20d386e47d5a58267b47ff3927f8070743911 (v1.4?), so no way to manipulate and save the histograms other than using their SAF representation is provided AFAIK.

**Description of the Change:**

Make protected members of `Histo` readable through getters.

**Benefits:**

This change allows to manipulate and save histograms in a user-defined way.

**Possible Drawbacks:**

**Related GitHub Issues:**
