### PR TITLE
Change the default ctag value to be true for truth c-jets

### DIFF
--- a/doc/releases/changelog-v1.10.md
+++ b/doc/releases/changelog-v1.10.md
@@ -149,5 +149,5 @@ This release contains contributions from (in alphabetical order):
 [Jack Y. Araz](https://github.com/jackaraz),
 [Kyle Fan](https://github.com/kfan326),
 [Matthew Feickert](https://github.com/matthewfeickert),
-[Benjamin Fuks](https://github.com/bfuks)
+[Benjamin Fuks](https://github.com/bfuks),
 [Bingxuan Liu](https://github.com/prbbing)

--- a/doc/releases/changelog-v1.10.md
+++ b/doc/releases/changelog-v1.10.md
@@ -66,6 +66,8 @@
   edge case bug fixes.
   ([#211](https://github.com/MadAnalysis/madanalysis5/pull/211))
 
+* Include c-tagging options.
+
 ## Bug fixes
 
 * Permanently fix the zlib version to the latest.
@@ -148,3 +150,4 @@ This release contains contributions from (in alphabetical order):
 [Kyle Fan](https://github.com/kfan326),
 [Matthew Feickert](https://github.com/matthewfeickert),
 [Benjamin Fuks](https://github.com/bfuks)
+[Bingxuan Liu](https://github.com/prbbing)

--- a/tools/SampleAnalyzer/Process/JetClustering/bTagger.cpp
+++ b/tools/SampleAnalyzer/Process/JetClustering/bTagger.cpp
@@ -108,6 +108,7 @@ void bTagger::Method1 (SampleFormat& mySample, EventFormat& myEvent)
 
     // 100% identification
     if (jet->true_btag_) jet->btag_=true;
+    if (jet->true_ctag_) jet->ctag_=true;
     if (!doEfficiency_ && !doMisefficiency_) continue;
 
     // identification efficiency


### PR DESCRIPTION
Set the default ctag value for truth c-jet to True

**Context:**

When testing the c-tagging functionality, it was found that the default c-tag value is not set to "true" for truth c-jets. As the default tagger logic is to set the c-tag to false when the criterion is met, this feature prevents the c-tagging from working out of the box (one can still makes it work by modifying the user code).

**Description of the Change:**

Adding a similar line in btagger.cpp as it was done for b-tagging b-jets solves the above issue, allowing us to perform c-tagging properly. 

**Benefits:**

Now if one loads a customized card involving c-tagging, the code generated by default works out of the box. 

**Possible Drawbacks:**

**Related GitHub Issues:**
