### PR TITLE
Draft: Allow output as .yoda file

### DIFF
--- a/doc/normal_mode/main_normal.tex
+++ b/doc/normal_mode/main_normal.tex
@@ -937,6 +937,10 @@ The list of available options is given below.
     generated ny \MA).\\
   \color{ao} \verb?store_root?    & Boolean indicatign whether the root file
     outputted by \DEL\ should be stored (the default value is \verb|false|).\\
+  \color{ao} \verb?store_yoda?    & Boolean indicating whether the output shall
+   also be stored as .yoda files (in adddition to .saf; the default value is \verb|false|).\\
+   \color{ao} \verb?TACO_output?    & A directory name indicating that the output shall be
+    given suitable as input for the TACO algorithm into the given directory (the default value is \verb|""|).\\
   \color{ao} \verb?THerror_combination? & Indicates how the theoretical
     uncertainties should be combined, \ie, either quadratically
     (\verb|quadratic|) or linearly (\verb|linear|, default).\\

--- a/madanalysis/IOinterface/job_writer.py
+++ b/madanalysis/IOinterface/job_writer.py
@@ -746,6 +746,9 @@ class JobWriter(object):
         if self.main.archi_info.has_root:
             options.has_root_inc = True
             options.has_root_lib = True
+        if self.main.archi_info.has_yoda:
+            options.has_yoda_inc = True
+            options.has_yoda_lib = True
         #options.has_userpackage = True
         toRemove=['Log/compilation.log','Log/linking.log','Log/cleanup.log','Log/mrproper.log']
 

--- a/madanalysis/IOinterface/job_writer.py
+++ b/madanalysis/IOinterface/job_writer.py
@@ -708,6 +708,9 @@ class JobWriter(object):
         if self.main.archi_info.has_root:
             options.has_root_inc = True
             options.has_root_lib = True
+        if self.main.archi_info.has_yoda:
+            options.has_yoda_inc = True
+            options.has_yoda_lib = True
         toRemove.extend(['compilation.log','linking.log','cleanup.log','mrproper.log'])
 
         # File to compile

--- a/madanalysis/IOinterface/library_writer.py
+++ b/madanalysis/IOinterface/library_writer.py
@@ -260,6 +260,9 @@ class LibraryWriter():
             options.has_zlib_tag              = self.main.archi_info.has_zlib
             options.has_root_tag              = self.main.archi_info.has_root
             options.has_root_ma5lib           = self.main.archi_info.has_root
+            options.has_yoda_tag              = self.main.archi_info.has_yoda
+            options.has_yoda_inc              = self.main.archi_info.has_yoda
+            options.has_yoda_lib              = self.main.archi_info.has_yoda
             toRemove.extend(['compilation.log','linking.log','cleanup.log','mrproper.log'])
         elif package=='test_process':
             options.has_commons               = True

--- a/madanalysis/build/makefile_writer.py
+++ b/madanalysis/build/makefile_writer.py
@@ -40,6 +40,7 @@ class MakefileWriter():
             self.has_fastjet        = False
             self.has_delphes        = False
             self.has_delphesMA5tune = False
+            self.has_yoda           = False
 
 
     @staticmethod
@@ -281,7 +282,6 @@ class MakefileWriter():
                 file.write('CXXFLAGS += '+' '.join(cxxflags)+'\n')
 
         # - root
-        print("has root inc: "+str(options.has_root_inc))
         if options.has_root_inc:
             cxxflags=[]
             cxxflags.extend(['$(shell $(MA5_BASE)/tools/SampleAnalyzer/ExternalSymLink/Bin/root-config --cflags)'])
@@ -315,12 +315,9 @@ class MakefileWriter():
             file.write('CXXFLAGS += '+' '.join(cxxflags)+'\n')
 
         # - YODA
-        print("has yoda inc: "+str(options.has_yoda_inc))
-        print(options)
         if options.has_yoda_inc:
             cxxflags=[]
             cxxflags.extend(['$(shell yoda-config --cflags)'])
-            #cxxflags.extend(['$(shell $(MA5_BASE)/tools/SampleAnalyzer/ExternalSymLink/Bin/root-config --cflags)'])
             file.write('CXXFLAGS += '+' '.join(cxxflags)+'\n')
 
         # - tags
@@ -417,10 +414,9 @@ class MakefileWriter():
 
         # - YODA
         if options.has_yoda_lib:
-            #libs.extend(['$(shell $(MA5_BASE)/tools/SampleAnalyzer/ExternalSymLink/Bin/yoda-config --libs) -lEG'])
+            libs=[]
             libs.extend(['$(shell yoda-config --libs)'])
             file.write('LIBFLAGS += '+' '.join(libs)+'\n')
-        #file.write('LIBFLAGS += `yoda-config --libs`\n')
 
         # - Commons
         if options.has_commons:

--- a/madanalysis/build/makefile_writer.py
+++ b/madanalysis/build/makefile_writer.py
@@ -169,21 +169,23 @@ class MakefileWriter():
             self.has_delphesMA5tune_tag    = False
             self.has_root_tag              = False
             self.has_zlib_tag              = False
+            self.has_yoda_tag              = False
             self.has_fastjet_inc           = False
             self.has_delphes_inc           = False
             self.has_delphesMA5tune_inc    = False
             self.has_zlib_inc              = False
             self.has_root_inc              = False
+            self.has_yoda_inc              = False
             self.has_fastjet_lib           = False
             self.has_delphes_lib           = False
             self.has_delphesMA5tune_lib    = False
             self.has_zlib_lib              = False
+            self.has_yoda_lib              = False
             self.has_fastjet_ma5lib        = False
             self.has_delphes_ma5lib        = False
             self.has_delphesMA5tune_ma5lib = False
             self.has_zlib_ma5lib           = False
             self.has_root                  = False
-            self.has_root_tag              = False
             self.has_root_lib              = False
             self.has_root_ma5lib           = False
 
@@ -222,7 +224,6 @@ class MakefileWriter():
         file.write('CXXFLAGS  = '+' '.join(cxxflags)+'\n')
         for item in moreIncludes:
             file.write('CXXFLAGS += '+' -I'+item+'\n')
-        file.write('CXXFLAGS += `yoda-config --cflags`\n')
 
         # - compilation severity
         if not options.has_root_inc    and not options.has_fastjet_inc and \
@@ -280,6 +281,7 @@ class MakefileWriter():
                 file.write('CXXFLAGS += '+' '.join(cxxflags)+'\n')
 
         # - root
+        print("has root inc: "+str(options.has_root_inc))
         if options.has_root_inc:
             cxxflags=[]
             cxxflags.extend(['$(shell $(MA5_BASE)/tools/SampleAnalyzer/ExternalSymLink/Bin/root-config --cflags)'])
@@ -312,6 +314,15 @@ class MakefileWriter():
                 cxxflags.extend(['-I'+header])
             file.write('CXXFLAGS += '+' '.join(cxxflags)+'\n')
 
+        # - YODA
+        print("has yoda inc: "+str(options.has_yoda_inc))
+        print(options)
+        if options.has_yoda_inc:
+            cxxflags=[]
+            cxxflags.extend(['$(shell yoda-config --cflags)'])
+            #cxxflags.extend(['$(shell $(MA5_BASE)/tools/SampleAnalyzer/ExternalSymLink/Bin/root-config --cflags)'])
+            file.write('CXXFLAGS += '+' '.join(cxxflags)+'\n')
+
         # - tags
         cxxflags=[]
         if options.has_root_tag:
@@ -324,6 +335,8 @@ class MakefileWriter():
              cxxflags.extend(['-DDELPHES_USE'])
         if options.has_delphesMA5tune_tag:
              cxxflags.extend(['-DDELPHESMA5TUNE_USE'])
+        if options.has_yoda_tag:
+             cxxflags.extend(['-DYODA_USE'])
         if len(cxxflags)!=0:
             file.write('CXXFLAGS += '+' '.join(cxxflags)+'\n')
         file.write('\n')
@@ -402,13 +415,18 @@ class MakefileWriter():
                 libs.extend(['-lDelphesMA5tune'])
             file.write('LIBFLAGS += '+' '.join(libs)+'\n')
 
+        # - YODA
+        if options.has_yoda_lib:
+            #libs.extend(['$(shell $(MA5_BASE)/tools/SampleAnalyzer/ExternalSymLink/Bin/yoda-config --libs) -lEG'])
+            libs.extend(['$(shell yoda-config --libs)'])
+            file.write('LIBFLAGS += '+' '.join(libs)+'\n')
+        #file.write('LIBFLAGS += `yoda-config --libs`\n')
+
         # - Commons
         if options.has_commons:
             libs=[]
             libs.extend(['-lcommons_for_ma5'])
             file.write('LIBFLAGS += '+' '.join(libs)+'\n')
-
-        file.write('LIBFLAGS += `yoda-config --libs`\n')
 
         # - Root
         libs=[]

--- a/madanalysis/build/makefile_writer.py
+++ b/madanalysis/build/makefile_writer.py
@@ -218,10 +218,11 @@ class MakefileWriter():
 
         # - general
         cxxflags=[]
-        cxxflags.extend(['-Wall','-std=c++11','-O3','-fPIC', '-I$(MA5_BASE)/tools/']) # general
+        cxxflags.extend(['-Wall','-std=c++17','-O3','-fPIC', '-I$(MA5_BASE)/tools/']) # general
         file.write('CXXFLAGS  = '+' '.join(cxxflags)+'\n')
         for item in moreIncludes:
             file.write('CXXFLAGS += '+' -I'+item+'\n')
+        file.write('CXXFLAGS += `yoda-config --cflags`\n')
 
         # - compilation severity
         if not options.has_root_inc    and not options.has_fastjet_inc and \
@@ -406,6 +407,8 @@ class MakefileWriter():
             libs=[]
             libs.extend(['-lcommons_for_ma5'])
             file.write('LIBFLAGS += '+' '.join(libs)+'\n')
+
+        file.write('LIBFLAGS += `yoda-config --libs`\n')
 
         # - Root
         libs=[]

--- a/madanalysis/configuration/recast_configuration.py
+++ b/madanalysis/configuration/recast_configuration.py
@@ -37,6 +37,7 @@ class RecastConfiguration:
          "card_path"              : "",\
          "store_root"             : ["True", "False"] , \
          "store_events"           : ["True", "False"] , \
+         "store_yoda"             : ["True", "False"] , \
          "THerror_combination"    : ["quadratic","linear"], \
          "error_extrapolation"    : ["linear", "sqrt"],\
          "global_likelihoods"     : ["on","off"],\
@@ -55,6 +56,7 @@ class RecastConfiguration:
         self.padsfs                     = False
         self.store_root                 = False
         self.store_events               = False
+        self.store_yoda                 = False
         self.TACO_output                = ""
         self.global_likelihoods_switch  = True
         self.CLs_calculator_backend     = "native"
@@ -104,6 +106,7 @@ class RecastConfiguration:
             self.user_DisplayParameter("CLs_numofexps")
             self.user_DisplayParameter("card_path")
             self.user_DisplayParameter("store_events")
+            self.user_DisplayParameter("store_yoda")
             self.user_DisplayParameter("TACO_output")
             self.user_DisplayParameter("extrapolated_luminosities")
             self.user_DisplayParameter("systematics")
@@ -157,8 +160,11 @@ class RecastConfiguration:
         elif parameter=="store_root" or parameter=="store_events":
             self.logger.info("   * Keeping the event files: "+str(self.store_root or self.store_events))
             return
+        elif parameter=="store_yoda":
+            self.logger.info("   * Storing results as .yoda files: "+str(self.store_yoda))
+            return
         elif parameter=="TACO_output":
-            self.logger.info("   * Running in TACO mode and storing the results at " +str(self.TACO_output));
+            self.logger.info("   * Running in TACO mode and storing the results at " +str(self.TACO_output))
             return
         elif parameter=="systematics":
             if len(self.systematics) > 0:
@@ -322,6 +328,13 @@ class RecastConfiguration:
                 self.logger.error("Do the root files need to be stored? (True/False)")
                 return
 
+        # Give results additionally as .yoda files
+        elif parameter=="store_yoda":
+            if self.status!="on":
+                self.logger.error("Please first set the recasting mode to 'on'.")
+                return
+            self.store_yoda = value
+
         # Running in TACO mode
         elif parameter=="TACO_output":
             if self.status!="on":
@@ -473,7 +486,7 @@ class RecastConfiguration:
             if var == "add":
                 table = ["extrapolated_luminosity", "systematics"]
             else:
-                table = ["CLs_numofexps", "card_path", "store_events", 'TACO_output', "add",
+                table = ["CLs_numofexps", "card_path", "store_events", "store_yoda", 'TACO_output', "add",
                          "THerror_combination", "error_extrapolation", "global_likelihoods",
                          "CLs_calculator_backend", "expectation_assumption"]#, "simplify_likelihoods"
         else:
@@ -483,30 +496,10 @@ class RecastConfiguration:
 
     def user_GetValues(self,variable):
         table = []
-        if variable=="status":
-                table.extend(RecastConfiguration.userVariables["status"])
-        elif variable =="CLs_numofexps":
-                table.extend(RecastConfiguration.userVariables["CLs_numofexps"])
-        elif variable =="card_path":
-                table.extend(RecastConfiguration.userVariables["card_path"])
-        elif variable =="store_root":
-                table.extend(RecastConfiguration.userVariables["store_root"])
-        elif variable =="store_events":
-                table.extend(RecastConfiguration.userVariables["store_events"])
-        elif variable =="TACO_output":
-                table.extend(RecastConfiguration.userVariables["TACO_output"])
-        elif variable =="THerror_combination":
-                table.extend(RecastConfiguration.userVariables["THerror_combination"])
-        elif variable =="error_extrapolation":
-                table.extend(RecastConfiguration.userVariables["error_extrapolation"])
-        elif variable =="global_likelihoods":
-                table.extend(RecastConfiguration.userVariables["global_likelihoods"])
-        elif variable =="CLs_calculator_backend":
-            table.extend(RecastConfiguration.userVariables["CLs_calculator_backend"])
-        elif variable =="simplify_likelihoods":
-            table.extend(RecastConfiguration.userVariables["simplify_likelihoods"])
-        elif variable =="expectation_assumption":
-            table.extend(RecastConfiguration.userVariables["expectation_assumption"])
+        if variable in ["status", "CLs_numofexps", "card_path", "store_root", "store_events", "store_yoda",
+                        "TACO_output", "THerror_combination", "error_extrapolation", "global_likelihoods",
+                        "CLs_calculator_backend", "simplify_likelihoods", "expectation_assumption"]:
+            table.extend(RecastConfiguration.userVariables[variable])
         return table
 
 

--- a/madanalysis/core/main.py
+++ b/madanalysis/core/main.py
@@ -640,6 +640,7 @@ class Main():
         options.has_fastjet        = self.archi_info.has_fastjet
         options.has_delphes        = self.archi_info.has_delphes
         options.has_delphesMA5tune = self.archi_info.has_delphesMA5tune
+        options.has_yoda           = self.archi_info.has_yoda
         #MakefileWriter.UserfriendlyMakefileForSampleAnalyzer(self.archi_info.ma5dir+'/tools/SampleAnalyzer/Makefile',options)
 
         # Writing the setup

--- a/madanalysis/misc/run_recast.py
+++ b/madanalysis/misc/run_recast.py
@@ -413,9 +413,10 @@ class RunRecast():
                     newfile.write('  WriterBase* writer1 = \n')
                     newfile.write('      manager.InitializeWriter("lhe","'+output_name+'");\n')
                     newfile.write('  if (writer1==0) return 1;\n\n')
-            elif '// Post initialization (creates the new output directory structure)' in line and self.TACO_output!='':
+            elif '// Initializing PhysicsService for MC' in line and self.TACO_output!='':
                 newfile.write('    std::ofstream out;\n      out.open(\"../Output/' + self.TACO_output+'\");\n')
-                newfile.write('\n      manager.HeadSR(out);\n      out << std::endl;\n');
+                newfile.write('\n      manager.HeadSR(out);\n      out << std::endl;\n')
+                newfile.write('\n'+line)
             elif '//Getting pointer to the clusterer' in line:
                 ignore=False
                 newfile.write(line)

--- a/madanalysis/misc/run_recast.py
+++ b/madanalysis/misc/run_recast.py
@@ -71,6 +71,7 @@ class RunRecast():
         self.is_apriori       = True
         self.cls_calculator   = cls
         self.TACO_output      = self.main.recasting.TACO_output
+        self.store_yoda       = self.main.recasting.store_yoda
 
     def init(self):
         ### First, the analyses to take care off
@@ -429,9 +430,12 @@ class RunRecast():
             elif '    }' in line:
                 newfile.write(line)
                 ignore=False
-            elif 'manager.Finalize(mySamples,myEvent);' in line and self.TACO_output!='':
-                newfile.write(line);
-                newfile.write('  out.close();\n');
+            elif 'manager.Finalize(mySamples,myEvent);' in line:
+                if self.store_yoda:
+                    line = line.replace(");", ",true);")
+                newfile.write(line)
+                if self.TACO_output!='':
+                    newfile.write('  out.close();\n')
             elif not ignore:
                 newfile.write(line)
         mainfile.close()
@@ -671,9 +675,12 @@ class RunRecast():
                 if self.TACO_output!='':
                     newfile.write('\nmanager.DumpSR(out);\n');
                 ignore=False
-            elif 'manager.Finalize(mySamples,myEvent);' in line and self.TACO_output!='':
-                newfile.write(line);
-                newfile.write('  out.close();\n');
+            elif 'manager.Finalize(mySamples,myEvent);' in line:
+                if self.store_yoda:
+                    line = line.replace(");", ",true);")
+                newfile.write(line)
+                if self.TACO_output!='':
+                    newfile.write('  out.close();\n')
             elif not ignore:
                 newfile.write(line)
 

--- a/madanalysis/system/architecture_info.py
+++ b/madanalysis/system/architecture_info.py
@@ -44,6 +44,7 @@ class ArchitectureInfo:
         self.has_zlib           = False
         self.has_delphes        = False
         self.has_delphesMA5tune = False
+        self.has_yoda           = False
 
         # Library to put before all the others?
         self.root_priority           = False

--- a/madanalysis/system/checkup.py
+++ b/madanalysis/system/checkup.py
@@ -311,8 +311,6 @@ class CheckUp():
             return False
         if not self.checker.Execute('latex'):
             return False
-        if not self.checker.Execute('YODA'):
-            return False
         return True
 
     def CheckOptionalProcessingPackages(self):

--- a/madanalysis/system/checkup.py
+++ b/madanalysis/system/checkup.py
@@ -326,6 +326,8 @@ class CheckUp():
             return False
         if not self.checker.Execute('root'):
             return False
+        if not self.checker.Execute('YODA'):
+            return False
 
         self.archi_info.has_delphes           = checker2.checkDelphes()
         self.archi_info.has_delphesMA5tune    = checker2.checkDelphesMA5tune()

--- a/madanalysis/system/checkup.py
+++ b/madanalysis/system/checkup.py
@@ -311,6 +311,8 @@ class CheckUp():
             return False
         if not self.checker.Execute('latex'):
             return False
+        if not self.checker.Execute('YODA'):
+            return False
         return True
 
     def CheckOptionalProcessingPackages(self):

--- a/madanalysis/system/detect_manager.py
+++ b/madanalysis/system/detect_manager.py
@@ -123,6 +123,9 @@ class DetectManager():
         elif package=='latex':
             from madanalysis.system.detect_latex import DetectLatex
             checker=DetectLatex(self.archi_info, self.user_info, self.session_info, self.debug)
+        elif package=='yoda':
+            from madanalysis.system.detect_yoda import DetectYODA
+            checker=DetectYODA(self.archi_info, self.user_info, self.session_info, self.debug)
         else:
             self.logger.error('the package "'+rawpackage+'" is unknown')
             return False

--- a/madanalysis/system/detect_yoda.py
+++ b/madanalysis/system/detect_yoda.py
@@ -34,7 +34,7 @@ class DetectYODA:
         self.user_info    = user_info
         self.session_info = session_info
         self.debug        = debug
-        self.name         = 'yoda'
+        self.name         = 'YODA'
         self.mandatory    = False
         self.log          = []
         self.logger       = logging.getLogger('MA5')
@@ -95,5 +95,5 @@ class DetectYODA:
 
 
     def SaveInfo(self):
-        self.session_info.has_yoda = True
+        self.archi_info.has_yoda = True
         return True

--- a/madanalysis/system/detect_yoda.py
+++ b/madanalysis/system/detect_yoda.py
@@ -84,8 +84,8 @@ class DetectYODA:
         word=word.rstrip()
         numbers = word.split('.')
         if len(numbers)>=1:
-            if numbers[0]=='0':
-                self.logger.error("Release must be greater than 2.0.0. Please upgrade the YODA version.")
+            if int(numbers[0])<2:
+                self.logger.warning("Release must be greater than 2.0.0. Please upgrade the YODA version.")
                 return DetectStatusType.UNFOUND,''
         else:
             self.logger.warning("Impossible to decode the YODA release")

--- a/madanalysis/system/user_info.py
+++ b/madanalysis/system/user_info.py
@@ -271,6 +271,14 @@ class UserInfo:
         elif option=='dvipdf_veto':
             self.dvipdf_veto=self.ConvertToBool(option,value,filename)
 
+        # YODA
+        elif option=='yoda_veto':
+            self.yoda_veto=self.ConvertToBool(option,value,filename)
+        elif option=='yoda_includes':
+            self.yoda_includes=value
+        elif option=='yoda_libs':
+            self.yoda_libs=value
+
         # other
         else:
             self.logger.warning(filename+': the option called "'+option+'" is not found')

--- a/madanalysis/system/user_info.py
+++ b/madanalysis/system/user_info.py
@@ -88,6 +88,11 @@ class UserInfo:
         # dvipdf
         self.dvipdf_veto = None
 
+        # YODA
+        self.yoda_veto     = None
+        self.yoda_includes = None
+        self.yoda_libs     = None
+
         # logger
         self.logger = logging.getLogger('MA5')
 

--- a/tools/SampleAnalyzer/Process/Core/SampleAnalyzer.cpp
+++ b/tools/SampleAnalyzer/Process/Core/SampleAnalyzer.cpp
@@ -792,6 +792,12 @@ MAbool SampleAnalyzer::Finalize(std::vector<SampleFormat>& mySamples,
     analyzers_[i]->Manager()->GetPlotManager()->Write_TextFormat(out);
     out.WriteFoot();
     out.Finalize();
+
+    // YODA
+    if(storeYODA){
+      std::string yodaname = analyzers_[i]->Output() + "/Histograms/histos.yoda";
+      analyzers_[i]->Manager()->GetPlotManager()->Write_YODA(yodaname);
+    }
   }
 
   // Linking the histos to the SRs
@@ -827,7 +833,7 @@ MAbool SampleAnalyzer::Finalize(std::vector<SampleFormat>& mySamples,
         std::string cleanName = CleanName(myRS->GetName());
         std::string yodaname = myanalysis->Output() + "/Cutflows/" +
           cleanName + ".yoda";
-        myRS->WriteCutflow("CF-"+cleanName, yodaname);
+        myRS->WriteCutflowYODA("CF-"+cleanName, yodaname);
       }
     }
   }

--- a/tools/SampleAnalyzer/Process/Core/SampleAnalyzer.cpp
+++ b/tools/SampleAnalyzer/Process/Core/SampleAnalyzer.cpp
@@ -737,7 +737,7 @@ inline std::string CleanName(const std::string &name)
 
 /// Finalize fuction
 MAbool SampleAnalyzer::Finalize(std::vector<SampleFormat>& mySamples, 
-                              EventFormat& myEvent)
+                              EventFormat& myEvent, bool storeYODA)
 {
   // -----------------------------------------------------------------------
   //                      DUMP NUMBER OF EVENT
@@ -823,10 +823,12 @@ MAbool SampleAnalyzer::Finalize(std::vector<SampleFormat>& mySamples,
       out.Finalize();
 
       // YODA
-      std::string cleanName = CleanName(myRS->GetName());
-      std::string yodaname = myanalysis->Output() + "/Cutflows/" + 
-         cleanName + ".yoda";
-      myRS->WriteCutflow("CF-"+cleanName, yodaname);
+      if(storeYODA){
+        std::string cleanName = CleanName(myRS->GetName());
+        std::string yodaname = myanalysis->Output() + "/Cutflows/" +
+          cleanName + ".yoda";
+        myRS->WriteCutflow("CF-"+cleanName, yodaname);
+      }
     }
   }
 

--- a/tools/SampleAnalyzer/Process/Core/SampleAnalyzer.cpp
+++ b/tools/SampleAnalyzer/Process/Core/SampleAnalyzer.cpp
@@ -812,6 +812,7 @@ MAbool SampleAnalyzer::Finalize(std::vector<SampleFormat>& mySamples,
     AnalyzerBase* myanalysis = analyzers_[i];
     for(MAuint32 j=0; j<myanalysis->Manager()->Regions().size(); j++)
     {
+      // SAF
       RegionSelection *myRS = myanalysis->Manager()->Regions()[j];
       std::string safname = myanalysis->Output() + "/Cutflows/" + 
          CleanName(myRS->GetName()) + ".saf";
@@ -820,6 +821,12 @@ MAbool SampleAnalyzer::Finalize(std::vector<SampleFormat>& mySamples,
       myRS->WriteCutflow(out);
       out.WriteFoot();
       out.Finalize();
+
+      // YODA
+      std::string cleanName = CleanName(myRS->GetName());
+      std::string yodaname = myanalysis->Output() + "/Cutflows/" + 
+         cleanName + ".yoda";
+      myRS->WriteCutflow("CF-"+cleanName, yodaname);
     }
   }
 

--- a/tools/SampleAnalyzer/Process/Core/SampleAnalyzer.h
+++ b/tools/SampleAnalyzer/Process/Core/SampleAnalyzer.h
@@ -141,7 +141,7 @@ class SampleAnalyzer
   StatusCode::Type NextFile(SampleFormat& mysample);
 
   /// Finalization of the SampleAnalyzer
-  MAbool Finalize(std::vector<SampleFormat>& mysamples, EventFormat& myevent);
+  MAbool Finalize(std::vector<SampleFormat>& mysamples, EventFormat& myevent, bool storeYODA=false);
 
   /// Updating the progress bar
   void UpdateProgressBar();

--- a/tools/SampleAnalyzer/Process/Counter/CounterManager.cpp
+++ b/tools/SampleAnalyzer/Process/Counter/CounterManager.cpp
@@ -25,9 +25,10 @@
 // SampleAnalyzer headers
 #include "SampleAnalyzer/Process/Counter/CounterManager.h"
 
-
+#ifdef YODA_USE
 #include "YODA/Histo.h"
 #include "YODA/WriterYODA.h"
+#endif
 
 
 using namespace MA5;
@@ -160,6 +161,7 @@ void CounterManager::Write_TextFormat(SAFWriter& output) const
   }
 }
 
+#ifdef YODA_USE
 /// Auxiliary function to set a bin value with number of entries, sumW and sumW2
 void setBin(YODA::BinnedHisto1D<std::string>& h, MAuint32 bin, Counter counter){
   const std::array<double, 2> sumW({counter.sumweight_.first, counter.sumweight_.first});
@@ -167,6 +169,7 @@ void setBin(YODA::BinnedHisto1D<std::string>& h, MAuint32 bin, Counter counter){
   YODA::Dbn<1> sumWdbn2(counter.nentries_.first, sumW, sumW2);
   h.set(bin, sumWdbn2);
 }
+#endif
 
 /// Write the counters in a YODA file
 void CounterManager::Write_TextFormat(std::string name, std::string yodaname) const
@@ -184,6 +187,7 @@ void CounterManager::Write_TextFormat(std::string name, std::string yodaname) co
     edges.emplace_back(counters_[i].name_);
   }
 
+  #ifdef YODA_USE
   // create histogram
   YODA::BinnedHisto1D<std::string> h(edges, name);
 
@@ -198,4 +202,5 @@ void CounterManager::Write_TextFormat(std::string name, std::string yodaname) co
 
   // write to file
   YODA::WriterYODA::write(yodaname, h);
+  #endif
 }

--- a/tools/SampleAnalyzer/Process/Counter/CounterManager.cpp
+++ b/tools/SampleAnalyzer/Process/Counter/CounterManager.cpp
@@ -163,20 +163,20 @@ void CounterManager::Write_TextFormat(SAFWriter& output) const
 
 #ifdef YODA_USE
 /// Auxiliary function to set a bin value with number of entries, sumW and sumW2
-void setBin(YODA::BinnedHisto1D<std::string>& h, MAuint32 bin, Counter counter){
+void setBin(YODA::BinnedHisto1D<std::string>& yodaHisto, MAuint32 bin, Counter counter){
   const std::array<double, 2> sumW({counter.sumweight_.first, counter.sumweight_.first});
   const std::array<double, 2> sumW2({counter.sumweight2_.first, counter.sumweight2_.first});
   YODA::Dbn<1> sumWdbn2(counter.nentries_.first, sumW, sumW2);
-  h.set(bin, sumWdbn2);
+  yodaHisto.set(bin, sumWdbn2);
 }
 #endif
 
 /// Write the counters in a YODA file
-void CounterManager::Write_TextFormat(std::string name, std::string yodaname) const
+void CounterManager::Write_YODA(std::string histoname, std::string yodaname) const
 {
   // check for valid histogram
   if(counters_.size()==0){
-    INFO << "      Skipping histogram with name '" << name << "' because it has "
+    INFO << "      Skipping histogram with name '" << histoname << "' because it has "
         << counters_.size() << " bins." << endmsg;
     return;
   }
@@ -189,7 +189,7 @@ void CounterManager::Write_TextFormat(std::string name, std::string yodaname) co
 
   #ifdef YODA_USE
   // create histogram
-  YODA::BinnedHisto1D<std::string> h(edges, name);
+  YODA::BinnedHisto1D<std::string> h(edges, histoname);
 
   // set initial values
   setBin(h, 1, initial_);

--- a/tools/SampleAnalyzer/Process/Counter/CounterManager.h
+++ b/tools/SampleAnalyzer/Process/Counter/CounterManager.h
@@ -101,6 +101,9 @@ class CounterManager
   /// Write the counters in a Text file
   void Write_TextFormat(SAFWriter& output) const;
 
+  /// Write the counters in a YODA file
+  void Write_TextFormat(std::string name, std::string yodaname) const;
+
   /// Write the counters in a ROOT file
   //  void Write_RootFormat(TFile* output) const;
 

--- a/tools/SampleAnalyzer/Process/Counter/CounterManager.h
+++ b/tools/SampleAnalyzer/Process/Counter/CounterManager.h
@@ -102,7 +102,7 @@ class CounterManager
   void Write_TextFormat(SAFWriter& output) const;
 
   /// Write the counters in a YODA file
-  void Write_TextFormat(std::string name, std::string yodaname) const;
+  void Write_YODA(std::string histoname, std::string yodaname) const;
 
   /// Write the counters in a ROOT file
   //  void Write_RootFormat(TFile* output) const;

--- a/tools/SampleAnalyzer/Process/Plot/Histo.cpp
+++ b/tools/SampleAnalyzer/Process/Plot/Histo.cpp
@@ -44,20 +44,20 @@ void Histo::Write_TextFormat(std::ostream* output)
 
 #ifdef YODA_USE
 /// Return the plot as a YODA file
-YODA::Estimate1D* Histo::ToYODA()
+std::shared_ptr<YODA::Estimate1D> Histo::ToYODA() const
 {
   // create histogram
-  YODA::Estimate1D* yodaHisto = new YODA::Estimate1D(nbins_, xmin_, xmax_, name_, name_);
+  YODA::Estimate1D yodaHisto(nbins_, xmin_, xmax_, name_, name_);
 
   // set bin values
-  yodaHisto->bins()[0].setVal(underflow_.first);
+  yodaHisto.bins()[0].setVal(underflow_.first);
   for (MAuint32 i=0;i<histo_.size();i++)
   {
-    yodaHisto->bins()[i+1].setVal(histo_[i].first);
+    yodaHisto.bins()[i+1].setVal(histo_[i].first);
   }
-  yodaHisto->bins()[histo_.size()+1].setVal(overflow_.first);
+  yodaHisto.bins()[histo_.size()+1].setVal(overflow_.first);
 
-  return yodaHisto;
+  return std::make_shared<YODA::Estimate1D>(yodaHisto);
 }
 #endif
 

--- a/tools/SampleAnalyzer/Process/Plot/Histo.cpp
+++ b/tools/SampleAnalyzer/Process/Plot/Histo.cpp
@@ -42,6 +42,25 @@ void Histo::Write_TextFormat(std::ostream* output)
   *output << std::endl;
 }
 
+#ifdef YODA_USE
+/// Return the plot as a YODA file
+YODA::Estimate1D* Histo::ToYODA()
+{
+  // create histogram
+  YODA::Estimate1D* yodaHisto = new YODA::Estimate1D(nbins_, xmin_, xmax_, name_, name_);
+
+  // set bin values
+  yodaHisto->bins()[0].setVal(underflow_.first);
+  for (MAuint32 i=0;i<histo_.size();i++)
+  {
+    yodaHisto->bins()[i+1].setVal(histo_[i].first);
+  }
+  yodaHisto->bins()[histo_.size()+1].setVal(overflow_.first);
+
+  return yodaHisto;
+}
+#endif
+
 
 /// Write the plot in a Text file
 void Histo::Write_TextFormatBody(std::ostream* output)

--- a/tools/SampleAnalyzer/Process/Plot/Histo.h
+++ b/tools/SampleAnalyzer/Process/Plot/Histo.h
@@ -210,6 +210,11 @@ class Histo : public PlotBase
   /// Write the plot in a ROOT file
   //  virtual void Write_RootFormat(std::pair<TH1F*,TH1F*>& histos);
 
+  #ifdef YODA_USE
+  /// return the plot as a YODA histogram
+  virtual YODA::Estimate1D* ToYODA();
+  #endif
+
  protected:
 
   /// Write the plot in a ROOT file

--- a/tools/SampleAnalyzer/Process/Plot/Histo.h
+++ b/tools/SampleAnalyzer/Process/Plot/Histo.h
@@ -212,7 +212,7 @@ class Histo : public PlotBase
 
   #ifdef YODA_USE
   /// return the plot as a YODA histogram
-  virtual YODA::Estimate1D* ToYODA();
+  virtual YODAEstimatePtr ToYODA() const;
   #endif
 
  protected:

--- a/tools/SampleAnalyzer/Process/Plot/HistoFrequency.h
+++ b/tools/SampleAnalyzer/Process/Plot/HistoFrequency.h
@@ -236,6 +236,13 @@ class HistoFrequency : public PlotBase
   }
   */
 
+  #ifdef YODA_USE
+  /// return the plot as a YODA histogram
+  virtual YODA::Estimate1D* ToYODA(){
+    ERROR << "ToYODA isn't implemented yet for HistoFrequency" << endmsg;
+  };
+  #endif
+
 };
 
 }

--- a/tools/SampleAnalyzer/Process/Plot/HistoFrequency.h
+++ b/tools/SampleAnalyzer/Process/Plot/HistoFrequency.h
@@ -238,7 +238,7 @@ class HistoFrequency : public PlotBase
 
   #ifdef YODA_USE
   /// return the plot as a YODA histogram
-  virtual YODA::Estimate1D* ToYODA(){
+  virtual YODAEstimatePtr ToYODA() const{
     ERROR << "ToYODA isn't implemented yet for HistoFrequency" << endmsg;
   };
   #endif

--- a/tools/SampleAnalyzer/Process/Plot/PlotBase.h
+++ b/tools/SampleAnalyzer/Process/Plot/PlotBase.h
@@ -107,7 +107,8 @@ class PlotBase
 
   #ifdef YODA_USE
   /// return the plot as a YODA histogram
-  virtual YODA::Estimate1D* ToYODA() = 0;
+  typedef std::shared_ptr<YODA::Estimate1D> YODAEstimatePtr;
+  virtual YODAEstimatePtr ToYODA() const = 0;
   #endif
 
   /// Increment number of events
@@ -132,7 +133,7 @@ class PlotBase
   { return nevents_; }
 
   // Return the name
-  std::string GetName()
+  std::string GetName() const
     { return name_; }
 
 };

--- a/tools/SampleAnalyzer/Process/Plot/PlotBase.h
+++ b/tools/SampleAnalyzer/Process/Plot/PlotBase.h
@@ -32,6 +32,10 @@
 #include <string>
 #include <cmath>
 
+#ifdef YODA_USE
+#include "YODA/Histo.h"
+#endif
+
 // SampleAnalyzer headers
 #include "SampleAnalyzer/Commons/Service/LogService.h"
 
@@ -100,6 +104,11 @@ class PlotBase
 
   /// Write the plot in a ROOT file
   virtual void Write_TextFormat(std::ostream* output) = 0;
+
+  #ifdef YODA_USE
+  /// return the plot as a YODA histogram
+  virtual YODA::Estimate1D* ToYODA() = 0;
+  #endif
 
   /// Increment number of events
   void IncrementNEvents(MAfloat64 weight=1.0)

--- a/tools/SampleAnalyzer/Process/Plot/PlotManager.cpp
+++ b/tools/SampleAnalyzer/Process/Plot/PlotManager.cpp
@@ -29,6 +29,10 @@
 #include <map>
 #include <sstream>
 
+#ifdef YODA_USE
+#include "YODA/Histo.h"
+#include "YODA/WriterYODA.h"
+#endif
 
 using namespace MA5;
 
@@ -39,4 +43,25 @@ void PlotManager::Write_TextFormat(SAFWriter& output)
     plots_[i]->Write_TextFormat(output.GetStream());
 }
 
+/// Write the counters in a YODA file
+void PlotManager::Write_YODA(std::string yodaname)
+{
+  #ifdef YODA_USE
 
+  std::vector<YODA::Estimate1D*> yodaHistos;
+
+  // collect histograms as YODA
+  for (MAuint32 i=0;i<plots_.size();i++)
+    yodaHistos.push_back(plots_[i]->ToYODA());
+
+  // write histograms
+  YODA::Writer& yodaWriter = YODA::WriterYODA::create();
+  yodaWriter.write(yodaname, yodaHistos);
+
+  // clean-up
+  for (auto yodaHisto : yodaHistos)
+    delete yodaHisto;
+  yodaHistos.clear();
+
+  #endif
+}

--- a/tools/SampleAnalyzer/Process/Plot/PlotManager.cpp
+++ b/tools/SampleAnalyzer/Process/Plot/PlotManager.cpp
@@ -44,24 +44,18 @@ void PlotManager::Write_TextFormat(SAFWriter& output)
 }
 
 /// Write the counters in a YODA file
-void PlotManager::Write_YODA(std::string yodaname)
+void PlotManager::Write_YODA(std::string yodaname) const
 {
   #ifdef YODA_USE
-
-  std::vector<YODA::Estimate1D*> yodaHistos;
+  std::vector<std::shared_ptr<YODA::Estimate1D>> yodaHistos;
 
   // collect histograms as YODA
-  for (MAuint32 i=0;i<plots_.size();i++)
-    yodaHistos.push_back(plots_[i]->ToYODA());
+  for (const PlotBase *plot : plots_){
+    yodaHistos.push_back(plot->ToYODA());
+  }
 
   // write histograms
   YODA::Writer& yodaWriter = YODA::WriterYODA::create();
   yodaWriter.write(yodaname, yodaHistos);
-
-  // clean-up
-  for (auto yodaHisto : yodaHistos)
-    delete yodaHisto;
-  yodaHistos.clear();
-
   #endif
 }

--- a/tools/SampleAnalyzer/Process/Plot/PlotManager.h
+++ b/tools/SampleAnalyzer/Process/Plot/PlotManager.h
@@ -139,6 +139,9 @@ class PlotManager
   /// Write the counters in a Text file
   void Write_TextFormat(SAFWriter& output);
 
+  /// Write the counters in a YODA file
+  void Write_YODA(std::string yodaname);
+
   /// Finalizing
   void Finalize()
   { Reset(); }

--- a/tools/SampleAnalyzer/Process/Plot/PlotManager.h
+++ b/tools/SampleAnalyzer/Process/Plot/PlotManager.h
@@ -140,7 +140,7 @@ class PlotManager
   void Write_TextFormat(SAFWriter& output);
 
   /// Write the counters in a YODA file
-  void Write_YODA(std::string yodaname);
+  void Write_YODA(std::string yodaname) const;
 
   /// Finalizing
   void Finalize()

--- a/tools/SampleAnalyzer/Process/RegionSelection/RegionSelection.h
+++ b/tools/SampleAnalyzer/Process/RegionSelection/RegionSelection.h
@@ -81,6 +81,10 @@ class RegionSelection
   void WriteCutflow(SAFWriter& output)
     { cutflow_.Write_TextFormat(output); }
 
+  /// Printing the cutflow as YODA file
+  void WriteCutflow(std::string name, std::string yodaname)
+    {  cutflow_.Write_TextFormat(name, yodaname); }
+
   /// Set methods
   void SetName(std::string name)
     { name_ = name; }

--- a/tools/SampleAnalyzer/Process/RegionSelection/RegionSelection.h
+++ b/tools/SampleAnalyzer/Process/RegionSelection/RegionSelection.h
@@ -82,8 +82,8 @@ class RegionSelection
     { cutflow_.Write_TextFormat(output); }
 
   /// Printing the cutflow as YODA file
-  void WriteCutflow(std::string name, std::string yodaname)
-    {  cutflow_.Write_TextFormat(name, yodaname); }
+  void WriteCutflowYODA(std::string histoname, std::string yodaname)
+    {  cutflow_.Write_YODA(histoname, yodaname); }
 
   /// Set methods
   void SetName(std::string name)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:
  - [ ] All new features must include a test sequence.
      If you've fixed a bug or added code that should be tested, add a 
      test sequence below for it to be checked by other developers.
  - [X] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `./doc/makedoc`.
  - [ ] Add a new entry to the [`doc/releases/changelog-dev.md`](/MadAnalysis/madanalysis5/blob/main/doc/releases/changelog-dev.md)
        file, summarizing the change, and including a link back to the PR.

For details please see the documentation [here](/MadAnalysis/madanalysis5/blob/main/CONTRIBUTING.md).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.
  
------------------------------------------------------------------------------------------------------------
  
**Context:**
The default output format for MadAnalysis is `.saf`. In particular Rivet uses `.yoda`. For comparisons of the tools, it is helpful if MadAnalysis can give its output as `.yoda` as well, if requested by the user.

**Description of the Change:**
- [X] Automatic check for YODA installation. If no YODA installation is found, all YODA functionality is disabled.
- [X] User can require output as `.yoda` files by adding `store_yoda = True` to their run card.
- [X] Functionality to give `.yoda` files as output added to `SampleAnalyzer::Finalize()`
- Support for
  - [X] `Histo`
  - [X] `CounterManager`
  - [ ] `HistoFrequency`
  - [ ] `HistoLogX`

**Benefits:**
Support for a different output format, `.yoda`.

**Possible Drawbacks:**
- Dependency on the (light-weight) YODA framework and API.
- Requires C++17.

**Related GitHub Issues:**
None.