### PR TITLE
Replace TMath::Max with std::max in the ROOT histogram plotting

### DIFF
--- a/madanalysis/layout/merging_plots.py
+++ b/madanalysis/layout/merging_plots.py
@@ -323,7 +323,7 @@ class MergingPlots:
         outputC.write('  legend->SetFillColor(0);\n')
         outputC.write('  legend->SetTextSize(0.04);\n')
         outputC.write('  legend->SetTextFont(22);\n')
-        outputC.write('  legend->SetY1(TMath::Max(0.15,0.97-0.10*legend->GetListOfPrimitives()->GetSize()));\n')
+        outputC.write('  legend->SetY1(std::max(0.15,0.97-0.10*legend->GetListOfPrimitives()->GetSize()));\n')
         outputC.write('  legend->Draw();\n')
         outputC.write('\n')
 

--- a/madanalysis/layout/plotflow.py
+++ b/madanalysis/layout/plotflow.py
@@ -512,7 +512,7 @@ class PlotFlow:
             outputC.write('  legend->SetFillColor(0);\n')
             outputC.write('  legend->SetTextSize(0.05);\n')
             outputC.write('  legend->SetTextFont(22);\n')
-            outputC.write('  legend->SetY1(TMath::Max(0.15,0.97-0.10*legend->GetListOfPrimitives()->GetSize()));\n')
+            outputC.write('  legend->SetY1(std::max(0.15,0.97-0.10*legend->GetListOfPrimitives()->GetSize()));\n')
             outputC.write('  legend->Draw();\n')
             outputC.write('\n')
 


### PR DESCRIPTION
**Context:**
Replace TMath::Max function with std::max in madanalysis/layout/plotflow.py and madanalysis/layout/merging_plots.py

**Description of the Change:**
This change was motivated as when running madanalysis, one encountered an error with the original code:
./selection_0.C:123:17: error: use of undeclared identifier 'TMath'

**Benefits:**
Output histograms could be created without compiling errors.

**Possible Drawbacks:**

None 

**Related GitHub Issues:**
None